### PR TITLE
[BUGFIX] Clean up local temporary file

### DIFF
--- a/Classes/Domain/Repository/ExplicitDataCacheRepository.php
+++ b/Classes/Domain/Repository/ExplicitDataCacheRepository.php
@@ -90,6 +90,21 @@ class ExplicitDataCacheRepository
     }
 
     /**
+     *
+     */
+    public function delete(int $storageId, string $publicId): void
+    {
+        $connection = $this->getConnection();
+        $connection->delete(
+            $this->tableName,
+            [
+                'storage' => $storageId,
+                'public_id_hash' => sha1($publicId),
+            ]
+        );
+    }
+
+    /**
      * @param array $options
      * @return string
      */


### PR DESCRIPTION
When replacing a file in the BE file module, we must clean up existing
possible local temporary file so that the thumbnail can
be correctly regenerated.